### PR TITLE
Add invisible type to Rank Card

### DIFF
--- a/typings/src/Rank.d.ts
+++ b/typings/src/Rank.d.ts
@@ -175,7 +175,7 @@ declare class Rank {
      * @param {number|boolean} width Status width
      * @returns {Rank}
      */
-    setStatus(status: "online" | "idle" | "dnd" | "offline" | "streaming", circle?: boolean, width?: number | boolean): Rank;
+    setStatus(status: "online" | "idle" | "dnd" | "offline" | "streaming" | "invisible", circle?: boolean, width?: number | boolean): Rank;
     /**
      * Set background image/color
      * @param {"COLOR"|"IMAGE"} type Background type


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added the invisible user presence type to the Rank Card typings.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here by typing #133 where 133 is the issue number. -->
Canvacord throws an error if you use the .setStatus with typescript.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
