### PR TITLE
Fix username discriminator x position

### DIFF
--- a/src/Rank.js
+++ b/src/Rank.js
@@ -532,8 +532,7 @@ class Rank {
             } else {
                 ctx.font = `26px ${ops.fontY}`;
                 ctx.fillStyle = this.data.discriminator.color;
-                ctx.textAlign = "center";
-                ctx.fillText(discrim, 320, 170);
+                ctx.fillText(discrim, 270, 170);
             }
             ctx.restore();
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I tried the discriminator feature with name text, and it only applies to short text, if the text is long the x position will change and will look like the screenshot image I attached
<!--- Describe your changes in detail -->

## Motivation and Context
Fix #162 issues
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here by typing #133 where 133 is the issue number. -->

## Screenshots (if appropriate):
Before
![before](https://github.com/neplextech/canvacord/assets/75566525/3d8f68aa-d139-460f-aa8b-e26f3de34545)
After
![after](https://github.com/neplextech/canvacord/assets/75566525/37d28c85-9966-4451-bdff-9d3b7215bdff)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
