### PR TITLE
refactor(loadImage): use stream/consumers

### DIFF
--- a/src/canvas/Canvacord.ts
+++ b/src/canvas/Canvacord.ts
@@ -8,6 +8,7 @@ import { TemplateFactory } from '../assets/TemplateFactory';
 
 export type ImageGeneratorImplementor = {
   [K in Lowercase<Exclude<keyof typeof TemplateFactory, 'Triggered'>>]: (
+    // @ts-expect-error
     ...args: Parameters<(typeof TemplateFactory)[Capitalize<K>]>
   ) => Promise<Buffer>;
 };


### PR DESCRIPTION
Use built-in `stream/consumers` to convert stream to buffer.