### PR TITLE
:art: Update NeoClassicalCard to include 'invisible' status color

### DIFF
--- a/packages/canvacord/src/components/rank-card/NeoClassicalCard.tsx
+++ b/packages/canvacord/src/components/rank-card/NeoClassicalCard.tsx
@@ -77,6 +77,7 @@ const Colors = {
   dnd: "#f04747",
   offline: "#747f8d",
   streaming: "#593695",
+  invisible: "#747f8d",
 };
 
 const clamp = (value: number) => Math.max(0, Math.min(100, value));


### PR DESCRIPTION
## Description
Update NeoClassicalCard to include 'invisible' status color

## Motivation and Context
To fix this https://github.com/neplextech/canvacord/pull/201#issuecomment-1986849011

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
